### PR TITLE
fix: replace regex monorepo detection with normalized root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.4.1]() (2026-03-31)
+
+### Bug Fixes
+
+* Replace regex-based monorepo detection with explicit string normalization to avoid runtime errors
+* Use normalized `application_root` consistently in custom headers and build spec templates
+
 ## [1.4.0]() (2026-03-01)
 
 ### Features

--- a/locals.tf
+++ b/locals.tf
@@ -1,6 +1,10 @@
 locals {
-  monorepo_pattern = "/[a-zA-Z]"
-  is_monorepo      = var.application_root != "" && regex(local.monorepo_pattern, var.application_root) != null
+  normalized_root = (
+    var.application_root == "" ||
+    var.application_root == "." ||
+    var.application_root == "./"
+  ) ? "" : trim(var.application_root, "/")
+  is_monorepo = local.normalized_root != ""
 
   build_spec  = var.enable_backend ? "${path.module}/templates/build_spec_with_backend.tftpl" : "${path.module}/templates/build_spec_frontend_only.tftpl"
   domain_name = var.sub_domain == "" ? var.dns_zone : "${var.sub_domain}.${var.dns_zone}"
@@ -19,7 +23,7 @@ locals {
   custom_headers = length(var.custom_headers) > 0 ? local.is_monorepo ? jsonencode({
     applications = [
       {
-        appRoot       = var.application_root
+        appRoot       = local.normalized_root
         customHeaders = var.custom_headers
       }
     ]

--- a/main.tf
+++ b/main.tf
@@ -9,7 +9,7 @@ resource "aws_amplify_app" "this" {
   access_token = var.github_token
 
   build_spec = templatefile(local.build_spec, {
-    application_root         = var.application_root
+    application_root         = local.normalized_root
     base_artifacts_directory = var.base_artifacts_directory
     build_command            = var.build_command
     install_command          = var.install_command


### PR DESCRIPTION
## Summary

### Why
`regex()` in Terraform throws on no match, making monorepo detection fragile. Also, `application_root` values like `"."` or `"./"` were not handled as non-monorepo.

### What
- Replace regex-based monorepo detection with explicit string normalization
- Use `normalized_root` consistently in custom headers and build spec (was using raw `var.application_root`)
- Fix ternary indentation in locals.tf
- Add CHANGELOG entry for 1.4.1

### Solution
Normalize `application_root` once (`trim` + explicit checks for `""`, `"."`, `"./"`), then use the normalized value everywhere — monorepo check, custom headers `appRoot`, and build spec template.

## Types of Changes
- [x] 🕷 Bug fix (non-breaking change which fixes an issue)

## Test Plan
- `terraform fmt` and `terraform validate` pass via pre-commit hooks
- Verify `application_root = "./"` results in `is_monorepo = false`
- Verify `application_root = "frontend"` results in correct `appRoot` in custom headers